### PR TITLE
Add .vscode with eslint settings for frontend folder

### DIFF
--- a/{{ cookiecutter.project_slug }}/.gitignore
+++ b/{{ cookiecutter.project_slug }}/.gitignore
@@ -1,1 +1,1 @@
-.vscode
+!.vscode

--- a/{{ cookiecutter.project_slug }}/.vscode/settings.json
+++ b/{{ cookiecutter.project_slug }}/.vscode/settings.json
@@ -1,0 +1,1 @@
+{ "eslint.workingDirectories": ["./frontend"] }


### PR DESCRIPTION
If not, the VSCode plugin does not kick-in.