### PR TITLE
Fix failing `make build-image` Dockerfile RUN command syntax

### DIFF
--- a/{{ cookiecutter.project_slug }}/backend/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/backend/Dockerfile
@@ -11,10 +11,8 @@ LABEL maintainer="{{ cookiecutter.author }} <{{ cookiecutter.email }}>" \
 COPY . .
 
 # Install local requirements and fix permissions
-RUN <<EOT
-    ./bin/pip install mxdev
-    mv requirements-docker.txt requirements.txt
-    ./bin/mxdev -c mx.ini
-    ./bin/pip install -r requirements-mxdev.txt
-    chown -R plone: /app
-EOT
+RUN ./bin/pip install mxdev \
+    && mv requirements-docker.txt requirements.txt \
+    && ./bin/mxdev -c mx.ini \
+    && ./bin/pip install -r requirements-mxdev.txt \
+    && chown -R plone: /app

--- a/{{ cookiecutter.project_slug }}/frontend/Dockerfile.default
+++ b/{{ cookiecutter.project_slug }}/frontend/Dockerfile.default
@@ -2,22 +2,18 @@
 FROM node:16-slim as base
 FROM base as builder
 
-RUN <<EOT
-    apt-get update
-    buildDeps="python3 build-essential git ca-certificates"
-    apt-get install -y --no-install-recommends $buildDeps
-    rm -rf /var/lib/apt/lists/*
-EOT
+RUN apt-get update \
+    && buildDeps="python3 build-essential git ca-certificates" \
+    && apt-get install -y --no-install-recommends $buildDeps \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --chown=node . /build/
 RUN corepack enable
 
 USER node
 WORKDIR /build
-RUN <<EOT
-    make install
-    yarn build
-EOT
+RUN make install \
+    && yarn build
 
 FROM base
 
@@ -26,13 +22,11 @@ LABEL maintainer="{{ cookiecutter.author }} <{{ cookiecutter.email }}>" \
       org.label-schema.description="{{ cookiecutter.project_title }} frontend image." \
       org.label-schema.vendor="{{ cookiecutter.author }}"
 
-RUN <<<EOT
-    apt-get update
-    buildDeps="busybox"
-    apt-get install -y --no-install-recommends $buildDeps
-    busybox --install -s
-    rm -rf /var/lib/apt/lists/*
-EOT
+RUN apt-get update \
+    && buildDeps="busybox" \
+    && apt-get install -y --no-install-recommends $buildDeps \
+    && busybox --install -s \
+    && rm -rf /var/lib/apt/lists/*
 
 
 USER node


### PR DESCRIPTION
See #54: Dockerfile `RUN` command "here" syntax does not work in recent Docker versions, for example Docker version 20.10.22 build 3a2c30b. I would expect that using line continuations with commands separated by the "&&" list operator would work on all recent Docker installations. This PR implements that.