### PR TITLE
fix #54 enforce usage of docker buildkit

### DIFF
--- a/{{ cookiecutter.project_slug }}/backend/Makefile
+++ b/{{ cookiecutter.project_slug }}/backend/Makefile
@@ -163,4 +163,4 @@ debug: instance/etc/zope.ini ## Run debug console
 
 .PHONY: build-image
 build-image:  ## Build Docker Image
-	@docker build . -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile --build-arg PLONE_VERSION=$(PLONE_VERSION)
+	DOCKER_BUILDKIT=1 @docker build  . -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile --build-arg PLONE_VERSION=$(PLONE_VERSION)

--- a/{{ cookiecutter.project_slug }}/backend/Makefile
+++ b/{{ cookiecutter.project_slug }}/backend/Makefile
@@ -163,4 +163,4 @@ debug: instance/etc/zope.ini ## Run debug console
 
 .PHONY: build-image
 build-image:  ## Build Docker Image
-	DOCKER_BUILDKIT=1 @docker build . -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile --build-arg PLONE_VERSION=$(PLONE_VERSION)
+	@DOCKER_BUILDKIT=1 docker build . -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile --build-arg PLONE_VERSION=$(PLONE_VERSION)

--- a/{{ cookiecutter.project_slug }}/backend/Makefile
+++ b/{{ cookiecutter.project_slug }}/backend/Makefile
@@ -163,4 +163,4 @@ debug: instance/etc/zope.ini ## Run debug console
 
 .PHONY: build-image
 build-image:  ## Build Docker Image
-	DOCKER_BUILDKIT=1 @docker build  . -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile --build-arg PLONE_VERSION=$(PLONE_VERSION)
+	DOCKER_BUILDKIT=1 @docker build . -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile --build-arg PLONE_VERSION=$(PLONE_VERSION)

--- a/{{ cookiecutter.project_slug }}/frontend/Makefile.default
+++ b/{{ cookiecutter.project_slug }}/frontend/Makefile.default
@@ -89,7 +89,7 @@ storybook: ## Generate Storybook
 
 .PHONY: build-image
 build-image:  ## Build Docker Image
-	@docker build . -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile
+	DOCKER_BUILDKIT=1 @docker build . -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile
 
 # Acceptance tests
 

--- a/{{ cookiecutter.project_slug }}/frontend/Makefile.default
+++ b/{{ cookiecutter.project_slug }}/frontend/Makefile.default
@@ -89,7 +89,7 @@ storybook: ## Generate Storybook
 
 .PHONY: build-image
 build-image:  ## Build Docker Image
-	DOCKER_BUILDKIT=1 @docker build . -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile
+	@DOCKER_BUILDKIT=1 docker build . -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile
 
 # Acceptance tests
 


### PR DESCRIPTION
usage without buildkit is considered legacy by docker, see https://docs.docker.com/build/buildkit/

fixes #54