### PR TITLE
Specify which address Docker should bind to

### DIFF
--- a/{{ cookiecutter.project_slug }}/devops/playbook-setup.yml
+++ b/{{ cookiecutter.project_slug }}/devops/playbook-setup.yml
@@ -39,6 +39,7 @@
       - name: Init a new swarm with default parameters
         community.docker.docker_swarm:
           state: present
+          advertise_addr: "{{ ansible_default_ipv4.address }}"
 
       - name: Create a network
         community.docker.docker_network:

--- a/{{ cookiecutter.project_slug }}/devops/playbook-setup.yml
+++ b/{{ cookiecutter.project_slug }}/devops/playbook-setup.yml
@@ -39,7 +39,7 @@
       - name: Init a new swarm with default parameters
         community.docker.docker_swarm:
           state: present
-          advertise_addr: "{{ ansible_default_ipv4.address }}"
+          advertise_addr: {{'"{{ ansible_default_ipv4.address }}"'}}
 
       - name: Create a network
         community.docker.docker_network:


### PR DESCRIPTION
While deploying to Digital Ocean I got an error because Docker could not determine which address to bind to. eth0 had 2 ipv4 addresses (one internal and one external). This specifies `advertise_addr` to use the same IP address that ansible is using to access the remote machine.

However, maybe we need something else in order to support ipv6 as well?