### PR TITLE
Allow usage of Alpha versions of Volto.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ make start-frontend
 
 ## Project Generation Options
 
-These are all the template options that will be prompted by the [Cookiecutter CLI](https://github.com/cookiecutter/cookiecutter) prior to generating your project.
+These are all the template options that will be prompted by the [Cookiecutter CLI](https://github.com/cookiecutter/cookiecutter) before generating your project.
 
 | Option                | Description                                                                                                                                          | Example                       |
 | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
@@ -102,7 +102,8 @@ These are all the template options that will be prompted by the [Cookiecutter CL
 | `email`               | The email address you want to identify yourself in the project.                                                                                      | **email@example.com**         |
 | `python_package_name` | Name of the Python package used to configure your project. It needs to be Python-importable, so no dashes, spaces or special characters are allowed. | **plone_site**                |
 | `plone_version`       | Plone version to be used. This queries for the latest available Plone 6 version and presents it to you as the default value.                         | **6.0.0**                     |
-| `volto_version`       | Volto (Plone Frontend) version to be used. This queries for the latest available stable Volto version and presents it to you as the default value.   | **16.4.1**                    |
+| `volto_version`       | Volto (Plone Frontend) version to be used. This queries for the latest available Volto version and presents it to you as the default value. If you want to use non-stable versions, set the `USE_VOLTO_ALPHA` environment variable. | **16.4.1**                    |
+| `volto_generator_version`       | Volto (Plone Frontend) Yeoman generator to be used. This queries for the latest available Volto Generator version and presents it to you as the default value. If you want to use non-stable versions, set the `USE_VOLTO_ALPHA` environment variable.   | **6.0.0**                    |
 | `language_code`       | Language to be used on the site.                                                                                                                     | **pt-br**                     |
 | `github_organization` | Used for GitHub and Docker repositories.                                                                                                             | **collective**                |
 | `container_registry`  | Container registry to be used.                                                                                                                       | **GitHub**                    |

--- a/local_extensions/__init__.py
+++ b/local_extensions/__init__.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 import requests
@@ -11,6 +12,15 @@ REGISTRIES = {
 
 VOLTO_MIN_VERSION = 16
 VOLTO_GENERATOR_MIN_VERSION = 6
+VOLTO_ALPHA = True if os.environ.get("USE_VOLTO_ALPHA") else False
+
+
+def latest_volto_version(versions, min_version):
+    valid = sorted(
+        [v for v in versions if int(v.split(".")[0]) >= min_version], reverse=True
+    )
+    valid = valid if VOLTO_ALPHA else [v for v in valid if "-" not in v]
+    return valid[0]
 
 
 @simple_filter
@@ -20,8 +30,7 @@ def latest_volto(v) -> str:
     resp = requests.get(url, headers={"Accept": "application/vnd.npm.install-v1+json"})
     data = resp.json()
     versions = [version for version in data["dist-tags"].values()]
-    valid_versions = [v for v in versions if int(v.split(".")[0]) >= VOLTO_MIN_VERSION]
-    return sorted(valid_versions, reverse=True, key=lambda v: ("-" not in v, v))[0]
+    return latest_volto_version(versions, VOLTO_MIN_VERSION)
 
 
 @simple_filter
@@ -31,10 +40,7 @@ def latest_volto_generator(v) -> str:
     resp = requests.get(url, headers={"Accept": "application/vnd.npm.install-v1+json"})
     data = resp.json()
     versions = [version for version in data["dist-tags"].values()]
-    valid_versions = [
-        v for v in versions if int(v.split(".")[0]) >= VOLTO_GENERATOR_MIN_VERSION
-    ]
-    return sorted(valid_versions, reverse=True, key=lambda v: ("-" not in v, v))[0]
+    return latest_volto_version(versions, VOLTO_GENERATOR_MIN_VERSION)
 
 
 @simple_filter


### PR DESCRIPTION
To use non-stable versions, set the `USE_VOLTO_ALPHA` environment variable when running cookiecutter.