### PR TITLE
vscode Python extensions requirements for working with pyproject.toml

### DIFF
--- a/{{ cookiecutter.project_slug }}/backend/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/backend/pyproject.toml
@@ -42,6 +42,12 @@ pycodestyle = ["+*"]
 pyflakes = ["+*"]
 "flake8-*" = ["+*"]
 
+[tool.flake8]
+format="grouped"
+max-line-length=88
+show_source=true
+max-complexity=25
+
 [tool.plone-code-analysis]
 paths = "src/{{ cookiecutter.python_package_name }}/setup.py src/{{ cookiecutter.python_package_name }}/src/ scripts/"
 paths_pyroma = "src/{{ cookiecutter.python_package_name }}"

--- a/{{ cookiecutter.project_slug }}/backend/requirements.txt
+++ b/{{ cookiecutter.project_slug }}/backend/requirements.txt
@@ -1,3 +1,4 @@
 -c constraints.txt
 
 zope.testrunner
+flake8-pyproject


### PR DESCRIPTION
Explanation:
https://github.com/microsoft/vscode-flake8/issues/135

Theres is yet another thing, it seems that vscode crashes when parsing `pyproject.toml`:

```
  File "/opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/configparser.py", line 1132, in _read
    raise e
configparser.ParsingError: Source contains parsing errors: 'pyproject.toml'
	[line  9]: '(\n'
	[line 22]: ')\n'
	[line 23]: "'''\n"
```

That also prevents that vscode start flake8 properly (it does nothing at all). It seems the problem is this multiline:

https://github.com/collective/cookiecutter-plone-starter/blob/main/%7B%7B%20cookiecutter.project_slug%20%7D%7D/backend/pyproject.toml#L10-L25

For some reason, it does not like it... :( Removing it, works again.