### PR TITLE
Mention --replay for aborted cookiecutter scaffolds and point to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ USE_VOLTO_ALPHA=1 pipx run cookiecutter gh:collective/cookiecutter-plone-starter
 ```
 
 
-### Restarting cookiecutter with previous answers
+### Use options to avoid prompts
 
 The cookiecutter template will ask a quite some questions.
 If the scaffoling fails later for whatever reason, you could restart the cookiecutter with '--replay'.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ You can use the [`--no-input`](https://cookiecutter.readthedocs.io/en/latest/cli
 
 #### `--replay` and `--replay-file`
 You can use the options [`--replay`](https://cookiecutter.readthedocs.io/en/latest/cli_options.html#cmdoption-cookiecutter-replay) and [`--replay-file`](https://cookiecutter.readthedocs.io/en/latest/cli_options.html#cmdoption-cookiecutter-replay-file) to not prompt for parameters and only use information entered previously or from a specified file.
-At every invocation cookiecutter saves your answers in a temporary file. 
 See [Replay Project Generation](https://cookiecutter.readthedocs.io/en/latest/advanced/replay.html) in the cookiecutter documentation for more information.
 
 ### Initial Build

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can use the [`--no-input`](https://cookiecutter.readthedocs.io/en/latest/cli
 
 
 #### `--replay` and `--replay-file`
-If the scaffoling fails later for whatever reason, you could restart the cookiecutter with '--replay'.
+You can use the options [`--replay`](https://cookiecutter.readthedocs.io/en/latest/cli_options.html#cmdoption-cookiecutter-replay) and [`--replay-file`](https://cookiecutter.readthedocs.io/en/latest/cli_options.html#cmdoption-cookiecutter-replay-file) to not prompt for parameters and only use information entered previously or from a specified file.
 At every invocation cookiecutter saves your answers in a temporary file. 
 See [Replay Project Generation](https://cookiecutter.readthedocs.io/en/latest/advanced/replay.html) in the cookiecutter documentation for more information.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,16 @@ USE_VOLTO_ALPHA=1 pipx run cookiecutter gh:collective/cookiecutter-plone-starter
 
 ### Use options to avoid prompts
 
-The cookiecutter template will ask a quite some questions.
+The cookiecutter will ask a lot of questions.
+You can use some of its options to avoid repeatedly entering the same values.
+
+
+#### `--no-input`
+
+You can use the [`--no-input`](https://cookiecutter.readthedocs.io/en/latest/cli_options.html#cmdoption-cookiecutter-no-input) option to make the cookiecutter not prompt for parameters and only use `cookiecutter.json` file content.
+
+
+#### `--replay` and `--replay-file`
 If the scaffoling fails later for whatever reason, you could restart the cookiecutter with '--replay'.
 At every invocation cookiecutter saves your answers in a temporary file. 
 See [Replay Project Generation](https://cookiecutter.readthedocs.io/en/latest/advanced/replay.html) in the cookiecutter documentation for more information.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ For alpha versions of Volto:
 USE_VOLTO_ALPHA=1 pipx run cookiecutter gh:collective/cookiecutter-plone-starter
 ```
 
+
+### Restarting cookiecutter with previous answers
+
+The cookiecutter template will ask a quite some questions.
+If the scaffoling fails later for whatever reason, you could restart the cookiecutter with '--replay'.
+At every invocation cookiecutter saves your answers in a temporary file. 
+See [Replay Project Generation](https://cookiecutter.readthedocs.io/en/latest/advanced/replay.html) in the cookiecutter documentation for more information.
+
 ### Initial Build
 
 ```shell


### PR DESCRIPTION
--replay is something that is not directly clear when you start using cookiecutter-plone-starter, but can cause a lot of frustration when users have to re-enter the questions again and again. 

I suggest we add a hint for this to the cookiecutter-plone-starter readme 