### PR TITLE
Make it possible to run the template without docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Welcome to **Cookiecutter Plone Starter**! Your one-stop solution to kickstart [
 
 - **pipx**: A handy tool for installing and running Python applications.
 - **NodeJS & Yarn**: Essential for managing and running JavaScript packages.
-- **Docker**: For containerization and easy deployment.
+- **Docker**: For containerization and easy deployment. (Optional)
 
 ### Installation Guide 🛠️
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -275,9 +275,8 @@ def prepare_backend():
     for step in steps:
         msg, command, shell, cwd = step
         print(f" - {msg}")
-        result = run_cmd(command, shell=shell, cwd=cwd)
-        if not result:
-            sys.exit(1)
+        run_cmd(command, shell=shell, cwd=cwd)
+        # Note: we intentionally don't exit if formatting fails.
 
 
 volto_version = "{{ cookiecutter.volto_version }}"


### PR DESCRIPTION
Fixes #79 

This makes it possible to run the template even if Docker is not installed or not running. In that case the "make format" step will log an error, but won't prevent the template from completing.