### PR TITLE
Replace deprecated gocept.pytestlayer with zope.pytestlayer

### DIFF
--- a/{{ cookiecutter.project_slug }}/backend/src/{{ cookiecutter.python_package_name }}/setup.py
+++ b/{{ cookiecutter.project_slug }}/backend/src/{{ cookiecutter.python_package_name }}/setup.py
@@ -56,7 +56,7 @@ setup(
             "pytest-plone>=0.2.0",
             "pytest-cov",
             "pytest",
-            "gocept.pytestlayer",
+            "zope.pytestlayer",
           {%- endif %}
           {%- if cookiecutter.python_test_framework != 'pytest' %}
             "parameterized",


### PR DESCRIPTION
Since this PR was merged on May 15, 2024 https://github.com/zopefoundation/zope.pytestlayer/commit/7fc1b2c1ee9ae2711c065173accd93e5fd161fd2

The following exception is now included in the gocept.pytestlayer module.

raise RuntimeError("'gocept.pytestlayer' is deprecated."
                   " Please use 'zope.pytestlayer' instead."
                   " They are compatible besides the name.")

This will raise an error in the tests job of the cookiecutter.project_slug backend workflow.

Changing gocept.pytestlayer to zope.pytestlayer in setup.py fixes the issue.